### PR TITLE
Android 16KB compatibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-linux-android]
+rustflags = [
+    "-C", "link-arg=-Wl,-z,max-page-size=16384",
+    "-C", "link-arg=-Wl,-z,common-page-size=16384"
+]

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(explicit_builtin_cfgs_in_flags)]
 mod jose;
 
 pub mod wrappers;


### PR DESCRIPTION
Add build flags to set 16kb page size and fix build script
https://developer.android.com/guide/practices/page-sizes
```
export ANDROID_NDK_HOME=/Users/harryanderson/Library/Android/sdk/ndk/27.1.12297006
./scripts/build.sh ANDROID
```
